### PR TITLE
Replay methods

### DIFF
--- a/al_mlp/atomistic_methods.py
+++ b/al_mlp/atomistic_methods.py
@@ -251,6 +251,10 @@ def base_replay(replay_func, calc, optimizer):
 
         # set r0 and f0 to last atom in dataset
         # just in case the last r0 and f0 were a while ago
+        if dataset[-1].info.get("check", False) is not True:
+            raise ValueError(
+                "most recent call was not to parent, replay cannot set optimizer"
+            )
         optimizer.r0 = dataset[-1].get_positions().ravel()
         optimizer.f0 = dataset[-1].get_forces(apply_constraint=False).ravel()
 

--- a/al_mlp/atomistic_methods.py
+++ b/al_mlp/atomistic_methods.py
@@ -237,7 +237,7 @@ def base_replay(replay_func, calc, optimizer):
         # for eligible atoms added to dataset, update the hessian using the replay function
         for atoms in dataset:
             atoms_ml = atoms.copy()
-            atoms_ml.calc = calc.ml_potential
+            atoms_ml.calc = calc.get_ml_calc()
 
             # pass both the base atoms and atoms with the ml calc in case replay function wants either
             r, f = replay_func(atoms, atoms_ml)

--- a/al_mlp/atomistic_methods.py
+++ b/al_mlp/atomistic_methods.py
@@ -172,6 +172,8 @@ class Relaxation:
                 dyn.attach(mixed_replay, 1, calc, dyn)
             elif replay_traj == "reset":
                 dyn.attach(reset_replay, 1, calc, dyn)
+            elif replay_traj == "parent_only":
+                dyn.attach(parent_only_replay, 1, calc, dyn)
             else:
                 raise ValueError("invalid replay method given")
 
@@ -268,6 +270,21 @@ def mixed_replay(calc, optimizer):
             atoms_copy.calc = calc.ml_potential
             r = atoms_copy.get_positions().ravel()
             f = atoms_copy.get_forces(apply_constraint=False).ravel()
+        return r, f
+
+    base_replay(replay_func, calc, optimizer)
+
+
+def parent_only_replay(calc, optimizer):
+    """Reinitialize hessian with parent calls only."""
+
+    def replay_func(atoms):
+        if atoms.info.get("check", False):
+            r = atoms.get_positions().ravel()
+            f = atoms.get_forces(apply_constraint=False).ravel()
+        else:
+            r = None
+            f = None
         return r, f
 
     base_replay(replay_func, calc, optimizer)

--- a/al_mlp/atomistic_methods.py
+++ b/al_mlp/atomistic_methods.py
@@ -170,6 +170,8 @@ class Relaxation:
                 dyn.attach(mixed_replay, 1, calc, dyn)
             elif replay_traj == "mixed":
                 dyn.attach(mixed_replay, 1, calc, dyn)
+            elif replay_traj == "reset":
+                dyn.attach(reset_replay, 1, calc, dyn)
             else:
                 raise ValueError("invalid replay method given")
 
@@ -243,6 +245,15 @@ def base_replay(replay_func, calc, optimizer):
         # just in case the last r0 and f0 were a while ago
         optimizer.r0 = dataset[-1].get_positions().ravel()
         optimizer.f0 = dataset[-1].get_forces(apply_constraint=False).ravel()
+
+
+def reset_replay(calc, optimizer):
+    """Reinitialize hessian from scratch."""
+
+    def reset_func(atoms):
+        return None, None
+
+    base_replay(reset_func, calc, optimizer)
 
 
 def mixed_replay(calc, optimizer):

--- a/al_mlp/atomistic_methods.py
+++ b/al_mlp/atomistic_methods.py
@@ -250,16 +250,16 @@ def base_replay(replay_func, calc, optimizer):
 def reset_replay(calc, optimizer):
     """Reinitialize hessian from scratch."""
 
-    def reset_func(atoms):
+    def replay_func(atoms):
         return None, None
 
-    base_replay(reset_func, calc, optimizer)
+    base_replay(replay_func, calc, optimizer)
 
 
 def mixed_replay(calc, optimizer):
     """Reinitialize hessian with parent calls and ml everywhere else."""
 
-    def mixed_func(atoms):
+    def replay_func(atoms):
         if atoms.info.get("check", False):
             r = atoms.get_positions().ravel()
             f = atoms.get_forces(apply_constraint=False).ravel()
@@ -270,4 +270,4 @@ def mixed_replay(calc, optimizer):
             f = atoms_copy.get_forces(apply_constraint=False).ravel()
         return r, f
 
-    base_replay(mixed_func, calc, optimizer)
+    base_replay(replay_func, calc, optimizer)

--- a/al_mlp/atomistic_methods.py
+++ b/al_mlp/atomistic_methods.py
@@ -235,8 +235,10 @@ def base_replay(replay_func, calc, optimizer):
             r0 = r
             f0 = f
 
-        optimizer.r0 = r0
-        optimizer.f0 = f0
+        # set r0 and f0 to last atom in dataset
+        # just in case the last r0 and f0 were a while ago
+        optimizer.r0 = dataset[-1].get_positions().ravel()
+        optimizer.f0 = dataset[-1].get_forces(apply_constraint=False).ravel()
 
 
 def mixed_replay(calc, optimizer):

--- a/al_mlp/atomistic_methods.py
+++ b/al_mlp/atomistic_methods.py
@@ -174,6 +174,8 @@ class Relaxation:
                 dyn.attach(reset_replay, 1, calc, dyn)
             elif replay_traj == "parent_only":
                 dyn.attach(parent_only_replay, 1, calc, dyn)
+            elif replay_traj == "ml_only":
+                dyn.attach(ml_only_replay, 1, calc, dyn)
             else:
                 raise ValueError("invalid replay method given")
 
@@ -285,6 +287,19 @@ def parent_only_replay(calc, optimizer):
         else:
             r = None
             f = None
+        return r, f
+
+    base_replay(replay_func, calc, optimizer)
+
+
+def ml_only_replay(calc, optimizer):
+    """Reinitialize hessian with current ml calls only."""
+
+    def replay_func(atoms):
+        atoms_copy = atoms.copy()
+        atoms_copy.calc = calc.ml_potential
+        r = atoms_copy.get_positions().ravel()
+        f = atoms_copy.get_forces(apply_constraint=False).ravel()
         return r, f
 
     base_replay(replay_func, calc, optimizer)

--- a/al_mlp/online_learner/online_learner.py
+++ b/al_mlp/online_learner/online_learner.py
@@ -163,6 +163,8 @@ class OnlineLearner(Calculator):
         # If we have less than two data points, uncertainty is not
         # well calibrated so just use DFT
         if len(self.parent_dataset) < self.num_initial_points:
+            atoms_copy.info["check"] = True
+
             energy, forces, constrained_forces = self.add_data_and_retrain(atoms_copy)
             fmax = np.sqrt((constrained_forces ** 2).sum(axis=1).max())
 
@@ -170,8 +172,6 @@ class OnlineLearner(Calculator):
             self.info["parent_energy"] = energy
             self.info["parent_forces"] = str(forces)
             self.info["parent_fmax"] = fmax
-
-            atoms_copy.info["check"] = True
 
             if len(self.parent_dataset) == self.num_initial_points:
                 new_parent_dataset = [
@@ -206,6 +206,8 @@ class OnlineLearner(Calculator):
 
             # If we are extrapolating too far add/retrain
             if need_to_retrain:
+                atoms_copy.info["check"] = True
+
                 energy_ML = energy
                 constrained_forces_ML = constrained_forces
                 # Run DFT, so use that energy/force
@@ -223,7 +225,6 @@ class OnlineLearner(Calculator):
                     constrained_forces - constrained_forces_ML
                 )
 
-                atoms_copy.info["check"] = True
             else:
                 # Otherwise use the ML predicted energies and forces
                 self.info["check"] = False


### PR DESCRIPTION
Added replay methods to attach to atomistic methods relaxation.
Reset (totally reset the hessian after each parent call)
ml_only (reinitialize hessian with all the points using current ml on each one after parent call)
parent_only (reinitialize hessian with only the parent calls)
mixed (default, reinitialize hessian with parent calls and current ml everywhere else, previously the only implementation)

Also fixed a bug associated with using the ml reinitialization and delta learner